### PR TITLE
feat: automatically add
  .heimdall/ to .gitignore on project init

### DIFF
--- a/heimdall/cli_commands/project_commands.py
+++ b/heimdall/cli_commands/project_commands.py
@@ -253,6 +253,34 @@ def project_init(
         heimdall_dir = project_path / ".heimdall"
         heimdall_dir.mkdir(exist_ok=True)
 
+        # Add .heimdall to .gitignore
+        gitignore_path = project_path / ".gitignore"
+        heimdall_entry = ".heimdall/"
+        
+        try:
+            if gitignore_path.exists():
+                # Read existing .gitignore
+                content = gitignore_path.read_text()
+                # Check if .heimdall/ is already in .gitignore
+                # Account for variations like .heimdall, .heimdall/, /.heimdall/
+                patterns = [".heimdall", ".heimdall/", "/.heimdall", "/.heimdall/"]
+                if not any(pattern in content for pattern in patterns):
+                    # Append to existing .gitignore
+                    with gitignore_path.open('a') as f:
+                        if not content.endswith('\n') and content:
+                            f.write('\n')
+                        f.write(f"{heimdall_entry}\n")
+                    console.print(f"📝 Added {heimdall_entry} to existing .gitignore", style="bold green")
+                else:
+                    console.print(f"✅ {heimdall_entry} already in .gitignore", style="dim")
+            else:
+                # Create new .gitignore
+                gitignore_path.write_text(f"{heimdall_entry}\n")
+                console.print(f"📝 Created .gitignore with {heimdall_entry}", style="bold green")
+        except Exception as e:
+            console.print(f"⚠️ Could not update .gitignore: {e}", style="bold yellow")
+            console.print(f"   Please add {heimdall_entry} to .gitignore manually", style="dim")
+
         # Create docs directory for monitoring
         docs_dir = heimdall_dir / "docs"
         docs_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
# Pull Request: Automatically add .heimdall/ to .gitignore on project init

## Summary

This PR enhances the `heimdall project init` command to automatically add `.heimdall/` to the project's `.gitignore` file, preventing the configuration directory from being accidentally committed to version control.

## Changes

Modified `heimdall/cli_commands/project_commands.py` in the `project_init` function to:
- Check if `.gitignore` exists in the project root
- Scan for existing `.heimdall` patterns (handles variations like `.heimdall`, `.heimdall/`, `/.heimdall/`)
- Append `.heimdall/` if not already present
- Create a new `.gitignore` with `.heimdall/` if the file doesn't exist
- Handle errors gracefully with user-friendly messages

## Code Changes

The logic is added after line 254 where the `.heimdall` directory is created:

```python
# Add .heimdall to .gitignore
gitignore_path = project_path / ".gitignore"
heimdall_entry = ".heimdall/"

try:
    if gitignore_path.exists():
        # Read existing .gitignore
        content = gitignore_path.read_text()
        # Check if .heimdall/ is already in .gitignore
        # Account for variations like .heimdall, .heimdall/, /.heimdall/
        patterns = [".heimdall", ".heimdall/", "/.heimdall", "/.heimdall/"]
        if not any(pattern in content for pattern in patterns):
            # Append to existing .gitignore
            with gitignore_path.open('a') as f:
                if not content.endswith('\n') and content:
                    f.write('\n')
                f.write(f"{heimdall_entry}\n")
            console.print(f"📝 Added {heimdall_entry} to existing .gitignore", style="bold green")
        else:
            console.print(f"✅ {heimdall_entry} already in .gitignore", style="dim")
    else:
        # Create new .gitignore
        gitignore_path.write_text(f"{heimdall_entry}\n")
        console.print(f"📝 Created .gitignore with {heimdall_entry}", style="bold green")
except Exception as e:
    console.print(f"⚠️ Could not update .gitignore: {e}", style="bold yellow")
    console.print(f"   Please add {heimdall_entry} to .gitignore manually", style="dim")
```

## Testing

The logic has been tested with the following scenarios:
1. **No existing .gitignore**: Creates new file with `.heimdall/`
2. **Existing .gitignore without .heimdall**: Appends `.heimdall/` with proper newline handling
3. **Existing .gitignore with .heimdall already**: Detects and skips, showing confirmation message
4. **Error handling**: Gracefully handles file permission or other errors

## Benefits

- Prevents accidental commits of project-specific configuration
- Eliminates need for manual .gitignore updates
- Provides clear feedback to users about gitignore status
- Handles edge cases and existing configurations properly

## Branch

The changes are available in the branch: `feature/auto-add-heimdall-to-gitignore`

## Commit

```
feat: automatically add .heimdall/ to .gitignore on project init

- Checks if .gitignore exists before modifying
- Handles various .heimdall patterns already in file
- Creates new .gitignore if it does not exist
- Provides user-friendly messages for all scenarios
- Gracefully handles errors with fallback instructions

This ensures .heimdall directory is never accidentally committed to version control.
```