### PR TITLE
Fix macOS permission error in port checking

### DIFF
--- a/heimdall/cognitive_system/service_manager.py
+++ b/heimdall/cognitive_system/service_manager.py
@@ -486,10 +486,15 @@ storage:
 
     def _is_port_in_use(self, port: int) -> bool:
         """Check if a port is in use."""
-        for conn in psutil.net_connections():
-            if conn.laddr.port == port:
-                return True
-        return False
+        import socket
+        try:
+            # Try to connect to the port - if successful, it's in use
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(1)  # 1 second timeout
+                result = sock.connect_ex(('localhost', port))
+                return result == 0
+        except Exception:
+            return False
 
 
 class ServiceManager:


### PR DESCRIPTION
## Summary
- Fixes psutil.net_connections() AccessDenied error on macOS
- Replaces system-wide network connection check with socket-based approach  
- Eliminates need for elevated privileges or SIP modifications

## Problem
The `heimdall project init` command was failing on macOS with a permission error when `psutil.net_connections()` tried to access network connections from all processes system-wide. This requires special entitlements that aren't available through macOS System Preferences.

## Solution
Replaced the problematic `psutil.net_connections()` call with a socket-based port check using `socket.connect_ex()`. This approach:
- Doesn't require elevated privileges
- Works on all platforms without special permissions
- Maintains the same functionality
- Is more efficient (only checks the specific port)

## Testing
- [x] Tested on macOS with SIP enabled
- [x] Confirms port detection works correctly
- [x] `heimdall project init` now runs successfully without sudo

## Files Changed
- `heimdall/cognitive_system/service_manager.py`: Updated `_is_port_in_use()` method

Closes #6